### PR TITLE
Fix RC migration URL

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -34,7 +34,7 @@ The following features are enabled for applications that are hosted in Sydney (*
     In the Sydney region, you use IAM access tokens with the {{site.data.keyword.speechtotextshort}} service for
 
     -   *New service instances* that you create after May 15. For more information, see [Authenticating with IAM tokens](/docs/services/watson/getting-started-iam.html).
-    -   *Existing service instances* that you migrate from Cloud Foundry to a resource group that is managed by the Resource Controller (RC). Service instances that were created before May 15 continue to use service credentials for authentication until you migrate them. For more information, see [Migrating Cloud Foundry service instances to a resource group](/docs/account/instance_migration.html).
+    -   *Existing service instances* that you migrate from Cloud Foundry to a resource group that is managed by the Resource Controller (RC). Service instances that were created before May 15 continue to use service credentials for authentication until you migrate them. For more information, see [Migrating Cloud Foundry service instances to a resource group](/docs/resources/instance_migration.html).
 
     All new and existing service instances in other regions continue to use service credentials (`{username}:{password}`) for authentication.
 


### PR DESCRIPTION
The instance_migration.md file has moved to `resources`. The `account` link redirects to `resources`, but doesn't behave properly when linked to from the service documentation.